### PR TITLE
Log Levels

### DIFF
--- a/Editor/PlayURSettingsProvider.cs
+++ b/Editor/PlayURSettingsProvider.cs
@@ -27,7 +27,8 @@ namespace PlayUR
         private SerializedProperty defaultSurveyPopupPrefab;
         private SerializedProperty defaultSurveyRowPrefab;
         private SerializedProperty mTurkLogo;
-        private SerializedProperty logLevelProperty;
+        private SerializedProperty logLevel;
+        private SerializedProperty logLevelToStore;
 
         private SerializedObject playurClientSecretSettings;
         private SerializedProperty clientSecretProperty;
@@ -117,6 +118,7 @@ namespace PlayUR
             public static GUIContent generalSettings = new GUIContent("General Settings");
             public static GUIContent standardSessionTracking = new GUIContent("Use Standard Session Tracking");
             public static GUIContent logLevel = new GUIContent("Log Level");
+            public static GUIContent logLevelToStore = new GUIContent("Storage Log Level");
 
             public static GUIContent mTurk = new GUIContent("MTurk Settings");
             public static GUIContent mTurkCompletionMessage = new GUIContent("MTurk Completion Message");
@@ -190,7 +192,8 @@ namespace PlayUR
             defaultSurveyRowPrefab = playurSettings.FindProperty("defaultSurveyRowPrefab");
             forceMTurkIDInEditor = playurSettings.FindProperty("forceMTurkIDInEditor");
             mTurkLogo = playurSettings.FindProperty("mTurkLogo");
-            logLevelProperty = playurSettings.FindProperty("minimumLogLevelToStore");
+            logLevel = playurSettings.FindProperty("logLevel");
+            logLevelToStore = playurSettings.FindProperty("minimumLogLevelToStore");
 
             playurClientSecretSettings = PlayURClientSecretSettings.GetSerializedSettings();
             clientSecretProperty = playurClientSecretSettings.FindProperty("clientSecret");
@@ -325,7 +328,8 @@ namespace PlayUR
             {
                 EditorGUI.indentLevel = 1;
                 EditorGUILayout.PropertyField(standardSessionTracking, Labels.standardSessionTracking);
-                EditorGUILayout.PropertyField(logLevelProperty, Labels.logLevel);
+                EditorGUILayout.PropertyField(logLevelToStore, Labels.logLevelToStore);
+                EditorGUILayout.PropertyField(logLevel, Labels.logLevel);
             }
             EditorGUILayout.EndFoldoutHeaderGroup();
             EditorGUI.indentLevel = 0;

--- a/Runtime/Core/PlayURPlugin.cs
+++ b/Runtime/Core/PlayURPlugin.cs
@@ -126,6 +126,7 @@ namespace PlayUR
         /// </summary>
         public static int GameID => Settings?.GameID ?? 0;
 
+
         /// <summary>Matches the client_secret field of the relevant game in the Game table in the server database.
         /// Is set on initial "Set Up" process, however if you need to update it, can be updated by running the set up process again.
         /// </summary>
@@ -1528,6 +1529,9 @@ namespace PlayUR
         /// <param name="context">The context object that Unity uses for highlighting when you click on the log message (optional).</param>
         public static void Log(object o, UnityEngine.Object context = null)
         {
+            if (Settings?.logLevel > LogLevel.Log)
+                return;
+
             if (o == null)
                 Debug.Log("[PlayUR] NULL", context);
             else
@@ -1541,6 +1545,9 @@ namespace PlayUR
         /// <param name="context">The context object that Unity uses for highlighting when you click on the log message (optional).</param>
         public static void LogError(object o, UnityEngine.Object context = null, bool breakCode = false)
         {
+            if (Settings?.logLevel > LogLevel.Error)
+                return;
+
             if (o == null)
                 Debug.LogError("[PlayUR] NULL", context);
             else
@@ -1559,6 +1566,9 @@ namespace PlayUR
         /// <param name="context">The context object that Unity uses for highlighting when you click on the log message (optional).</param>
         public static void LogWarning(object o, UnityEngine.Object context = null)
         {
+            if (Settings?.logLevel > LogLevel.Warning)
+                return;
+
             if (o == null)
                 Debug.LogWarning("[PlayUR] NULL", context);
             else

--- a/Runtime/Core/PlayURPlugin.cs
+++ b/Runtime/Core/PlayURPlugin.cs
@@ -832,7 +832,7 @@ namespace PlayUR
             }
             catch (ParameterNotFoundException)
             {
-                if (warn) Debug.LogWarning("Parameter " + key + " not found, using default value");
+                if (warn) PlayURPlugin.LogWarning("Parameter " + key + " not found, using default value");
                 return defaultValue;
             }
         }
@@ -874,7 +874,7 @@ namespace PlayUR
             }
             catch (ParameterNotFoundException)
             {
-                if (warn) Debug.LogWarning("Parameter " + key + " not found, using default value");
+                if (warn) PlayURPlugin.LogWarning("Parameter " + key + " not found, using default value");
                 return defaultValue;
             }
             catch (ArgumentNullException) //thrown if int.Parse fails
@@ -920,7 +920,7 @@ namespace PlayUR
             }
             catch (ParameterNotFoundException)
             {
-                if (warn) Debug.LogWarning("Parameter " + key + " not found, using default value");
+                if (warn) PlayURPlugin.LogWarning("Parameter " + key + " not found, using default value");
                 return defaultValue;
             }
             catch (ArgumentNullException) //thrown if int.Parse fails
@@ -966,7 +966,7 @@ namespace PlayUR
             }
             catch (ParameterNotFoundException)
             {
-                if (warn) Debug.LogWarning("Parameter " + key + " not found, using default value");
+                if (warn) PlayURPlugin.LogWarning("Parameter " + key + " not found, using default value");
                 return defaultValue;
             }
             catch (ArgumentNullException) //thrown if int.Parse fails
@@ -1273,7 +1273,7 @@ namespace PlayUR
                 {
                     int highlightRowID = -1;
                     if (data != null) int.TryParse(data["id"], out highlightRowID);
-                    //Debug.Log("highlight row "+highlightRowID+ "("+data["id"].ToString()+")");
+                    //PlayURPlugin.Log("highlight row "+highlightRowID+ "("+data["id"].ToString()+")");
                     ShowHighScoreTable(leaderboardID, configuration, highlightRowID, leaderboardPrefab, onCanvas, height, showCloseButton, keyCodeForClose, closeCallback);
                 }
             }, extraFields);

--- a/Runtime/Core/PlayURSettings.cs
+++ b/Runtime/Core/PlayURSettings.cs
@@ -99,6 +99,11 @@ namespace PlayUR
         /// </summary>
         public PlayURPlugin.LogLevel minimumLogLevelToStore = PlayURPlugin.LogLevel.Log;
 
+        /// <summary>
+        /// The minimum level to log to the console.
+        /// </summary>
+        public PlayURPlugin.LogLevel logLevel = PlayURPlugin.LogLevel.Log;
+
 #if UNITY_EDITOR
         internal static PlayURSettings GetOrCreateSettings()
         {
@@ -108,6 +113,7 @@ namespace PlayUR
                 settings = ScriptableObject.CreateInstance<PlayURSettings>();
                 settings.gameId = 0;
                 settings.minimumLogLevelToStore = PlayURPlugin.LogLevel.Log;
+                settings.logLevel = PlayURPlugin.LogLevel.Log;
 
                 var runtimeFolder = Path.Combine("Packages","io.playur.unity", "Runtime");
                 settings.defaultHighScoreTablePrefab = AssetDatabase.LoadAssetAtPath<GameObject>(Path.Combine(runtimeFolder, "HighScores", "HighScoreTable.prefab"));

--- a/Runtime/Utils/RestRequest.cs
+++ b/Runtime/Utils/RestRequest.cs
@@ -152,7 +152,7 @@ namespace PlayUR.Core
         public void ProcessImmediate()
         {
             // Suggestion by https://stackoverflow.com/a/60447131/5010271
-            Debug.Log("<color=#FF0000>WARNING: Request has been set to immedaite! This will break unity for a short while!!!</color>");
+            PlayURPlugin.Log("<color=#FF0000>WARNING: Request has been set to immedaite! This will break unity for a short while!!!</color>");
             IsProcessing = false;
 
             while (_pending.Count > 0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "io.playur.unity",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "displayName": "PlayUR Plugin",
   "description": "Unity plugin wrapper for the PlayUR platform (https://playur.io).",
   "unity": "2019.4",


### PR DESCRIPTION
Adds the ability to configure what level PlayUR actually logs this. 
This is useful mostly while debugging and testing as you often want to read your own log messages, but PlayUR fills the console with REST requests and other debug information. 

![log level screenshot](https://i.lu.je/2023/Unity_r4r9wxlAcF.png)