### PR TITLE
Fixed package export configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,10 +32,12 @@ jobs:
           dotnet tools/UnityPackageExporter.dll \
             ./ \
             PlayUR.unitypackage \
-            --exclude "Documentation" \
+            --sub-folder "PlayUR" \
             --exclude "tools" \
+            --exclude "*~" \
             --exclude ".*" \
-            --assets "**/*" \
+            --exclude "*.unitypackage" \
+            --skip-dependency-check \
             -r .
         
       # Upload artifact


### PR DESCRIPTION
In my own libraries, i have discovered an issue when exporting Unity Packages using my tooling. This has been fixed however in this commit https://github.com/Lachee/Unity-Package-Exporter/commit/67c1b8c98320bca82b1a21381521566c1277b94b. Additionally, https://github.com/Lachee/Unity-Package-Exporter/commit/795abe28558839b0a7252e8f118385ed97021e6e adds the ability to put all the exported assets under a specific sub folder.

Nothing needs to be done to apply these fixes. However, i have updated the release workflow to put everything under a PlayUR sub folder, as well as include & exclude erroneous files. 