### PR TITLE
Build Runner Fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
         
       # Upload artifact
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3.0.0
+        uses: actions/upload-artifact@v4
         with:
           name: "PlayUR Unity Plugin"
           path: PlayUR.unitypackage
@@ -70,7 +70,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
   
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           path: artifacts
 

--- a/Runtime/Resources.meta
+++ b/Runtime/Resources.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: cc2106a139d50924186ffc842e8c53b0
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
This will hopefully fix the runner not working in PlayUR.
The Resources folder still had a .metadata and the packager was freaking out.