### PR TITLE
Fixed experiment group naming

### DIFF
--- a/Editor/PlayURPluginEditor.cs
+++ b/Editor/PlayURPluginEditor.cs
@@ -161,7 +161,7 @@ namespace PlayUR.Editor
                     {
                         if (string.IsNullOrEmpty(group["name"].Value)) continue;
                         text += PlayUREditorUtils.DescriptionToCommentSafe(group["description"], indent: 2, id: group["id"], "ExperimentGroup", "Game/" + PlayURPlugin.GameID +"/"+ group["experimentID"].Value);
-                        text += "\t\t" + PlayUREditorUtils.PlatformNameToValidEnumValue(group["experiment"].Value) + "_" + group["name"].Value.Replace(" ", "") + " = " + group["id"] + ",\n";
+                        text += "\t\t" + PlayUREditorUtils.PlatformNameToValidEnumValue(group["experiment"].Value + " " + group["name"].Value) + " = " + group["id"] + ",\n";
                     }
                     text += "\t}" + GENERATED_FILE_FOOTER;
 


### PR DESCRIPTION
This fixes issue #29 

A name like `Full - Non Gamified` now results in `Vanilla_Full__Non_Gamified`.
The double underscore might be a issue, but for now i feel that it is an acceptable compromise.